### PR TITLE
Add command to restart TS Server with debug port listening

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,13 @@ An extension for working in the TypeScript codebase.
 
 ## Features
 
-It's not too smart yet, but it lets you choose a test file and re-run that file easily from anywhere in your editor.
+- Choose a test file and re-run that file easily from anywhere in your editor.
+- Restart VS Code’s TS Server process with a debug port listening. Handy for debugging language service features in a real world environment:
+  1. Open the TypeScript codebase in VS Code. Run `npm run build` in the console.
+  2. Open any other TypeScript codebase in another VS Code window.
+  3. In that codebase, edit or create `.vscode/settings.json` to include the option `"typescript.tsdk": "../path/to/TypeScript/built/local"`.
+  4. Open any TypeScript file in that same window and run the command “TSC: Restart TS Server with debugging enabled”
+  5. Back in the TypeScript codebase window, run command “Debug: Attach to Node Process.” You should see a VS Code process listening on port 9229 (or nearby if 9229 was busy).
 
 ### For more information
 

--- a/package.json
+++ b/package.json
@@ -15,22 +15,44 @@
     "Other"
   ],
   "activationEvents": [
-    "workspaceContains:**/src/compiler/checker.ts"
+    "onLanguage:typescript",
+    "onLanguage:typescriptreact"
   ],
   "main": "./out/extension.js",
   "contributes": {
     "commands": [
       {
         "command": "io.orta.typescript-dev.declare-current-test-file",
-        "title": "TSC: Declare current test file",
+        "title": "Declare current test file",
         "category": "TSC"
       },
       {
         "command": "io.orta.typescript-dev.run-current-test-file",
-        "title": "TSC: Run tests",
+        "title": "Run tests",
+        "category": "TSC"
+      },
+      {
+        "command": "io.orta.typescript-dev.restart-with-debugging",
+        "title": "Restart TS Server with debugging enabled",
         "category": "TSC"
       }
-    ]
+    ],
+    "menus": {
+      "commandPalette": [
+        {
+          "command": "io.orta.typescript-dev.declare-current-test-file",
+          "when": "workspaceContains:**/src/compiler/checker.ts"
+        },
+        {
+          "command": "io.orta.typescript-dev.run-current-test-file",
+          "when": "workspaceContains:**/src/compiler/checker.ts"
+        },
+        {
+          "command": "io.orta.typescript-dev.restart-with-debugging",
+          "when": "editorLangId =~ /^typescript/"
+        }
+      ]
+    }
   },
   "scripts": {
     "vscode:prepublish": "yarn run compile",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,13 +1,20 @@
 import * as vscode from "vscode"
 import { basename } from "path"
+import { findFreePort } from "./lib/findFreePort"
 
 export function activate(context: vscode.ExtensionContext) {
   const funcs = handleTestFiles()
-  let disposable = vscode.commands.registerCommand("io.orta.typescript-dev.declare-current-test-file", funcs.set)
-  context.subscriptions.push(disposable)
+  context.subscriptions.push(
+    vscode.commands.registerCommand("io.orta.typescript-dev.declare-current-test-file", funcs.set)
+  )
 
-  let disposable2 = vscode.commands.registerCommand("io.orta.typescript-dev.run-current-test-file", funcs.run)
-  context.subscriptions.push(disposable2)
+  context.subscriptions.push(
+    vscode.commands.registerCommand("io.orta.typescript-dev.run-current-test-file", funcs.run)
+  )
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("io.orta.typescript-dev.restart-with-debugging", restartWithDebuggingEnabled)
+  )
 
   // https://code.visualstudio.com/api/extension-guides/task-provider
   vscode.tasks.registerTaskProvider("tsc-dev", {
@@ -106,5 +113,10 @@ const handleTestFiles = () => {
   }
 }
 
+async function restartWithDebuggingEnabled() {
+  process.env.TSS_DEBUG = String(await findFreePort(9229, 1000, 1000));
+  return vscode.commands.executeCommand("typescript.restartTsServer");
+}
+
 // this method is called when your extension is deactivated
-export function deactivate() {}
+export function deactivate() { }

--- a/src/lib/LICENSE.txt
+++ b/src/lib/LICENSE.txt
@@ -1,0 +1,23 @@
+MIT License
+
+Copyright (c) 2015 - present Microsoft Corporation
+
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/lib/findFreePort.ts
+++ b/src/lib/findFreePort.ts
@@ -1,0 +1,89 @@
+// Copied from https://github.com/microsoft/vscode/blob/608fc2cee2f1a4c832d8c23b9d4e28805ddf6041/src/vs/base/node/ports.ts
+// under the MIT license. An exact copy of the license and copyright notice from the source version can be found at
+// src/lib/LICENSE.txt, and applies to the recursive contents of the `src/lib` directory.
+
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as net from 'net';
+
+/**
+ * @returns Returns a random port between 1025 and 65535.
+ */
+export function randomPort(): number {
+  const min = 1025;
+  const max = 65535;
+  return min + Math.floor((max - min) * Math.random());
+}
+
+/**
+ * Given a start point and a max number of retries, will find a port that
+ * is openable. Will return 0 in case no free port can be found.
+ */
+export function findFreePort(startPort: number, giveUpAfter: number, timeout: number): Promise<number> {
+  let done = false;
+
+  return new Promise(resolve => {
+    const timeoutHandle = setTimeout(() => {
+      if (!done) {
+        done = true;
+        return resolve(0);
+      }
+    }, timeout);
+
+    doFindFreePort(startPort, giveUpAfter, (port) => {
+      if (!done) {
+        done = true;
+        clearTimeout(timeoutHandle);
+        return resolve(port);
+      }
+    });
+  });
+}
+
+function doFindFreePort(startPort: number, giveUpAfter: number, clb: (port: number) => void): void {
+  if (giveUpAfter === 0) {
+    return clb(0);
+  }
+
+  const client = new net.Socket();
+
+  // If we can connect to the port it means the port is already taken so we continue searching
+  client.once('connect', () => {
+    dispose(client);
+
+    return doFindFreePort(startPort + 1, giveUpAfter - 1, clb);
+  });
+
+  client.once('data', () => {
+    // this listener is required since node.js 8.x
+  });
+
+  client.once('error', (err: Error & { code?: string }) => {
+    dispose(client);
+
+    // If we receive any non ECONNREFUSED error, it means the port is used but we cannot connect
+    if (err.code !== 'ECONNREFUSED') {
+      return doFindFreePort(startPort + 1, giveUpAfter - 1, clb);
+    }
+
+    // Otherwise it means the port is free to use!
+    return clb(startPort);
+  });
+
+  client.connect(startPort, '127.0.0.1');
+}
+
+function dispose(socket: net.Socket): void {
+  try {
+    socket.removeAllListeners('connect');
+    socket.removeAllListeners('error');
+    socket.end();
+    socket.destroy();
+    socket.unref();
+  } catch (error) {
+    console.error(error); // otherwise this error would get lost in the callback chain
+  }
+}


### PR DESCRIPTION
- Included `findFreePort` from vscode codebase since it’s not public. I can do something small and unsmart (such as pick a random unlikely port number) if you’d rather.
- Let me know if you think this would be better as a separate extension since it's not directly related to the TS codebase, but this greatly expedites one of my most common workflows that I really only started doing when I started working on TS ¯\\_(ツ)_/¯ 