### PR TITLE
Add zero-based position features

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@
 
 It's not too smart yet, but:
 
-- it lets you choose a test file and re-run that file easily from anywhere in your editor.
+- It lets you choose a test file and re-run that file easily from anywhere in your editor.
 - It adds syntax highlighting for .types and .symbol files in a way which won't fill your screen with errors.
+- It adds a command and an optional status bar indicator for the selection’s zero-based position in the current file
 
   - Symbol files ![](./screenshots/symbols.png)
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "Other"
   ],
   "activationEvents": [
-    "workspaceContains:**/src/compiler/checker.ts"
+    "workspaceContains:**/*.{ts,js,tsx,jsx}"
   ],
   "main": "./out/extension.js",
   "contributes": {
@@ -48,15 +48,45 @@
     "commands": [
       {
         "command": "io.orta.typescript-dev.declare-current-test-file",
-        "title": "TSC: Declare current test file",
+        "title": "Declare current test file",
         "category": "TSC"
       },
       {
         "command": "io.orta.typescript-dev.run-current-test-file",
-        "title": "TSC: Run tests",
+        "title": "Run tests",
+        "category": "TSC"
+      },
+      {
+        "command": "io.orta.typescript-dev.go-to-position",
+        "title": "Go to position",
+        "category": "TSC"
+      },
+      {
+        "command": "io.orta.typescript-dev.toggle-position",
+        "title": "Toggle position indicator in status bar",
         "category": "TSC"
       }
-    ]
+    ],
+    "menus": {
+      "commandPalette": [
+        {
+          "command": "io.orta.typescript-dev.declare-current-test-file",
+          "when": "io.orta.typescript-dev.isTypeScriptCodeBase"
+        },
+        {
+          "command": "io.orta.typescript-dev.run-current-test-file",
+          "when": "io.orta.typescript-dev.isTypeScriptCodeBase"
+        },
+        {
+          "command": "io.orta.typescript-dev.go-to-position",
+          "when": "editorFocus"
+        },
+        {
+          "command": "io.orta.typescript-dev.toggle-position",
+          "when": "editorFocus"
+        }
+      ]
+    }
   },
   "scripts": {
     "vscode:prepublish": "yarn run compile",
@@ -72,8 +102,8 @@
     "@types/vscode": "^1.36.0",
     "glob": "^7.1.4",
     "mocha": "^6.1.4",
-    "typescript": "^3.3.1",
     "tslint": "^5.12.1",
+    "typescript": "^4.0.0-dev.20200803",
     "vscode-test": "^1.0.0-next.0"
   }
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,0 +1,6 @@
+import * as vscode from "vscode"
+
+export function setTypeScriptCodeBaseContext() {
+  const isTypeScriptCodeBase = !!vscode.workspace.workspaceFolders?.some(f => f.name === "TypeScript")
+  vscode.commands.executeCommand("setContext", "io.orta.typescript-dev.isTypeScriptCodeBase", isTypeScriptCodeBase)
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,7 @@
 import * as vscode from "vscode"
 import { basename } from "path"
+import { activatePosition } from "./position"
+import { setTypeScriptCodeBaseContext } from "./context"
 
 export function activate(context: vscode.ExtensionContext) {
   const funcs = handleTestFiles()
@@ -8,6 +10,10 @@ export function activate(context: vscode.ExtensionContext) {
 
   let disposable2 = vscode.commands.registerCommand("io.orta.typescript-dev.run-current-test-file", funcs.run)
   context.subscriptions.push(disposable2)
+
+  context.subscriptions.push(vscode.workspace.onDidChangeWorkspaceFolders(setTypeScriptCodeBaseContext));
+  setTypeScriptCodeBaseContext();
+  activatePosition(context)
 
   // https://code.visualstudio.com/api/extension-guides/task-provider
   vscode.tasks.registerTaskProvider("tsc-dev", {
@@ -107,4 +113,4 @@ const handleTestFiles = () => {
 }
 
 // this method is called when your extension is deactivated
-export function deactivate() {}
+export function deactivate() { }

--- a/src/position.ts
+++ b/src/position.ts
@@ -1,0 +1,148 @@
+import * as vscode from "vscode";
+
+const goToPositionCommandName = "io.orta.typescript-dev.go-to-position";
+const togglePositionCommandName = "io.orta.typescript-dev.toggle-position";
+
+export function activatePosition(context: vscode.ExtensionContext) {
+  context.subscriptions.push(vscode.commands.registerCommand(goToPositionCommandName, async () => {
+    const expr = await vscode.window.showInputBox({
+      prompt: "Zero-based position or comma-separated range. Addition and subtraction expressions are allowed."
+    });
+
+    if (vscode.window.activeTextEditor && expr) {
+      const range = tryParseRangeExpression(expr);
+      if (range !== undefined && vscode.window.activeTextEditor) {
+        const start = vscode.window.activeTextEditor.document.positionAt(range[0]);
+        const end = range[1] === undefined ? start : vscode.window.activeTextEditor.document.positionAt(range[1]);
+        vscode.window.activeTextEditor.selection = new vscode.Selection(start, end);
+      }
+
+      vscode.window.activeTextEditor.revealRange(vscode.window.activeTextEditor.selection, vscode.TextEditorRevealType.InCenterIfOutsideViewport);
+    }
+  }));
+
+  let positionStatusBarItem: vscode.StatusBarItem;
+  let positionStatusBarItemVisible = false; // This seems to be private state of `StatusBarItem`, so I have to track it myself?
+  context.subscriptions.push(vscode.commands.registerCommand(togglePositionCommandName, () => {
+    if (!positionStatusBarItem) {
+      positionStatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100.45);
+      positionStatusBarItem.command = goToPositionCommandName;
+      context.subscriptions.push(positionStatusBarItem);
+      context.subscriptions.push(vscode.window.onDidChangeActiveTextEditor(() => updatePosition(positionStatusBarItem)));
+      context.subscriptions.push(vscode.window.onDidChangeTextEditorSelection(() => updatePosition(positionStatusBarItem)));
+      updatePosition(positionStatusBarItem);
+    }
+
+    if (positionStatusBarItemVisible) {
+      positionStatusBarItem.hide();
+    } else {
+      positionStatusBarItem.show();
+    }
+    positionStatusBarItemVisible = !positionStatusBarItemVisible;
+  }));
+}
+
+function updatePosition(statusBarItem: vscode.StatusBarItem) {
+  const focus = vscode.window.activeTextEditor?.document.offsetAt(vscode.window.activeTextEditor.selection.active);
+  const anchor = vscode.window.activeTextEditor?.document.offsetAt(vscode.window.activeTextEditor.selection.anchor);
+  if (focus !== undefined && anchor !== undefined) {
+    const lower = Math.min(focus, anchor);
+    const upper = Math.max(focus, anchor);
+    statusBarItem.text = "Pos " + lower + (upper === lower ? "" : `, ${upper}`);
+  }
+}
+
+export function tryParseRangeExpression(expr: string): readonly [number, number | undefined] | undefined {
+  const [startExpr, endExpr] = expr.split(",");
+  const start = tryParsePositionExpression(startExpr);
+  if (start === undefined) return undefined;
+  return [start, endExpr === undefined ? endExpr : tryParsePositionExpression(endExpr)];
+}
+
+function tryParsePositionExpression(expr: string): number | undefined {
+  const enum State {
+    ParseOperator,
+    ParseOperand,
+  }
+
+  let state = State.ParseOperand as State;
+  let value: number | undefined;
+  let operator: "+" | "-" = "+";
+  let pos = 0;
+
+  while (pos < expr.length) {
+    skipSpace();
+    const current = expr[pos];
+    if (!current) break;
+
+    switch (state) {
+      case State.ParseOperand:
+        if (isNumeric(current)) {
+          value = operate(consumeInt());
+          state = State.ParseOperator;
+          continue;
+        } else if (current === "+") {
+          pos++;
+          continue;
+        } else if (current === "-") {
+          flipSign();
+          pos++;
+          continue;
+        } else {
+          return undefined;
+        }
+      case State.ParseOperator:
+        if (current === "+") {
+          operator = "+";
+          pos++;
+          state = State.ParseOperand;
+        } else if (current === "-") {
+          operator = "-";
+          pos++;
+          state = State.ParseOperand;
+        } else {
+          return undefined;
+        }
+    }
+  }
+  return value !== undefined && value >= 0 ? value : undefined;
+
+  function consumeInt(): number | undefined {
+    let start = pos;
+    while (pos < expr.length && isNumeric(expr[pos])) {
+      pos++;
+    }
+    const int = +expr.slice(start, pos);
+    if (Number.isSafeInteger(int)) {
+      return int;
+    }
+  }
+
+  function skipSpace() {
+    while (pos < expr.length && /\s/.test(expr[pos])) {
+      pos++;
+    }
+  }
+
+  function operate(operand: number | undefined) {
+    if (operand === undefined) return value;
+    if (value === undefined) value = 0;
+    switch (operator) {
+      case "+": return value + operand;
+      case "-": return value - operand;
+    }
+  }
+
+  function flipSign() {
+    if (operator === "+") {
+      operator = "-";
+    } else {
+      operator = "+";
+    }
+  }
+}
+
+function isNumeric(char: string) {
+  const code = char.charCodeAt(0);
+  return 48 <= code && code <= 57;
+}

--- a/src/test/suite/position.test.ts
+++ b/src/test/suite/position.test.ts
@@ -1,0 +1,36 @@
+import * as assert from "assert";
+import { tryParseRangeExpression } from "../../position";
+
+suite("Go To Position", () => {
+  test("parses simple expressions", () => {
+    assert.deepStrictEqual(tryParseRangeExpression("3"), [3, undefined]);
+    assert.deepStrictEqual(tryParseRangeExpression("422424"), [422424, undefined]);
+    assert.deepStrictEqual(tryParseRangeExpression("   7    "), [7, undefined]);
+  });
+
+  test("parses +/- arithmetic", () => {
+    assert.deepStrictEqual(tryParseRangeExpression("3+5"), [8, undefined]);
+    assert.deepStrictEqual(tryParseRangeExpression("3-1"), [2, undefined]);
+    assert.deepStrictEqual(tryParseRangeExpression("3 - 1 + 4"), [6, undefined]);
+    assert.deepStrictEqual(tryParseRangeExpression("+3 + -1"), [2, undefined]);
+    assert.deepStrictEqual(tryParseRangeExpression("3--1"), [4, undefined]);
+    assert.deepStrictEqual(tryParseRangeExpression("-   6 + + 7"), [1, undefined]);
+  });
+
+  test("rejects bad input", () => {
+    assert.deepStrictEqual(tryParseRangeExpression("3 * 1"), undefined);
+    assert.deepStrictEqual(tryParseRangeExpression("-1"), undefined);
+    assert.deepStrictEqual(tryParseRangeExpression("a"), undefined);
+    assert.deepStrictEqual(tryParseRangeExpression("0x23"), undefined);
+    assert.deepStrictEqual(tryParseRangeExpression(", 24"), undefined);
+    assert.deepStrictEqual(tryParseRangeExpression("throw new Error()"), undefined);
+  });
+
+  test("parses ranges", () => {
+    assert.deepStrictEqual(tryParseRangeExpression("3, 7"), [3, 7]);
+    assert.deepStrictEqual(tryParseRangeExpression("3 + 1 , 7 - 1"), [4, 6]);
+    assert.deepStrictEqual(tryParseRangeExpression("3,4,5"), [3, 4]);
+    assert.deepStrictEqual(tryParseRangeExpression("3,,,,4"), [3, undefined]);
+    assert.deepStrictEqual(tryParseRangeExpression("3, 2"), [3, 2]);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -869,10 +869,10 @@ tsutils@^2.29.0:
   dependencies:
     tslib "^1.8.1"
 
-typescript@^3.3.1:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
-  integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
+typescript@^4.0.0-dev.20200803:
+  version "4.0.0-dev.20200803"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.0-dev.20200803.tgz#ea8b0e9fb2ee3085598ff200c8568f04f4cbb2ba"
+  integrity sha512-f/jDkFqCs0gbUd5MCUijO9u3AOMx1x1HdRDDHSidlc6uPVEkRduxjeTFhIXbGutO7ivzv+aC2sxH+1FQwsyBcg==
 
 vscode-test@^1.0.0-next.0:
   version "1.0.0"


### PR DESCRIPTION
- Extension is enabled in any file in a workspace that contains TS/JS files (TS test-related commands only appear if the workspace contains a folder named "TypeScript")
- Adds a “Go to position” command (accepts ranges and simple +/- arithmetic expressions)
- Adds a “Toggle position indicator in status bar command”

![Kapture 2020-08-03 at 14 39 08](https://user-images.githubusercontent.com/3277153/89229866-24a82a00-d597-11ea-8185-72df251f37d6.gif)
