### PR TITLE
Fix URIs used to open files from baselines list

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,12 +32,12 @@ export function activate(context: vscode.ExtensionContext) {
   const diffTool = vscode.commands.registerCommand("tsDev.openDiffTool", () => require("child_process").exec("gulp diff"));
 
   const open = vscode.commands.registerCommand("tsDev.openReferenceShort", (item: TreeNode) => {
-    vscode.commands.executeCommand("vscode.open", vscode.Uri.parse(item.uri.fsPath.replace("local", "reference")));
+    vscode.commands.executeCommand("vscode.open", vscode.Uri.file(item.uri.fsPath.replace("local", "reference")));
   });
 
   const diff = vscode.commands.registerCommand("tsDev.openDiffShort", (item: TreeNode) => {
-    const local = vscode.Uri.parse(item.uri.fsPath);
-    const ref = vscode.Uri.parse(item.uri.fsPath.replace("local", "reference"));
+    const local = vscode.Uri.file(item.uri.fsPath);
+    const ref = vscode.Uri.file(item.uri.fsPath.replace("local", "reference"));
     vscode.commands.executeCommand("vscode.diff", ref, local, `Diff for ${item.display}`);
   });
 
@@ -54,10 +54,10 @@ export function activate(context: vscode.ExtensionContext) {
       const [path, line] = testFile.split(":");
       const opts: vscode.TextDocumentShowOptions = line
         ? {
-            selection: new vscode.Range(new vscode.Position(Number(line), 0), new vscode.Position(Number(line), 0)),
-          }
+          selection: new vscode.Range(new vscode.Position(Number(line), 0), new vscode.Position(Number(line), 0)),
+        }
         : {};
-      vscode.commands.executeCommand("vscode.open", vscode.Uri.parse(path), opts);
+      vscode.commands.executeCommand("vscode.open", vscode.Uri.file(path), opts);
     }
   });
 


### PR DESCRIPTION
Without this change I constantly get error notification like this every time I click Diff ot Ref in baselines list
```
Unable to open 'Diff for parseBigInt.errors.txt': Unable to resolve resource c:%5Cweb%5Cprojects%5CTypeScript%5Ctests%5Cbaselines%5Clocal%5CparseBigInt.errors.txt.
```

Tested on Windows and Remote - WSL.
Haven't checked on Linux or Mac but [according to docs](https://code.visualstudio.com/api/references/vscode-api#Uri) this is correct method to use with paths on disk if you don't force scheme (in this case it interpreted `c:` as scheme on Windows).